### PR TITLE
build: create manual workflow to delete Alessandrina stacks

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,74 @@
+name: Clenaup Alessandrina stacks
+
+on:
+  workflow_dispatch:
+    inputs:
+      delete:
+        description: 'Are you sure you want to delete the stacks?'
+        required: true
+        default: 'false'
+
+env:
+  SAM_TEMPLATE: template.yaml
+  DEV_STACK_NAME: alessandrina-dev
+  DEV_PIPELINE_EXECUTION_ROLE: ${{ secrets.DEV_PIPELINE_EXECUTION_ROLE }}
+  DEV_ARTIFACTS_BUCKET: ${{ secrets.DEV_ARTIFACTS_BUCKET }}
+  DEV_REGION: us-east-1
+  PROD_STACK_NAME: alessandrina-prod
+  PROD_PIPELINE_EXECUTION_ROLE: ${{ secrets.PROD_PIPELINE_EXECUTION_ROLE }}
+  PROD_ARTIFACTS_BUCKET: ${{ secrets.PROD_ARTIFACTS_BUCKET }}
+  PROD_REGION: us-east-1
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  delete-prod-stack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - name: Assume the prod pipeline user role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ env.PROD_REGION }}
+          role-to-assume: ${{ env.PROD_PIPELINE_EXECUTION_ROLE }}
+          role-session-name: prod-deletion
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Delete prod stack
+        run: |
+          sam delete \
+            --stack-name ${PROD_STACK_NAME} \
+            --region ${PROD_REGION} \
+            --no-prompts
+
+  delete-dev-stack:
+    runs-on: ubuntu-latest
+    needs: [delete-prod-stack]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - name: Assume the dev pipeline user role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ env.DEV_REGION }}
+          role-to-assume: ${{ env.DEV_PIPELINE_EXECUTION_ROLE }}
+          role-session-name: dev-deletion
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Delete dev stack
+        run: |
+          sam delete \
+            --stack-name ${DEV_STACK_NAME} \
+            --region ${DEV_REGION} \
+            --no-prompts


### PR DESCRIPTION
Create a manual workflow to delete the Alessandrina stacks deployed for the development and production environment to avoid incurring additional costs on AWS.