### PR TITLE
fix: install artillery plugins; remove apdex

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -235,6 +235,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install additional dependencies
+        run: npm install -g artillery-plugin-expect artillery-plugin-ensure
+
       - name: Make reports directory
         run: mkdir reports
 

--- a/tests/performance/create-book-load.yml
+++ b/tests/performance/create-book-load.yml
@@ -40,7 +40,8 @@ config:
       arrivalRate: 15
       rampTo: 0
   plugins:
-    apedex: {}
+    ensure: {}
+    expect: {}
 scenarios:
   - flow:
     - post:


### PR DESCRIPTION
This PR installs the `ensure` and `expect` in the Artillery.io container and removes the `apdex` plugin.