### PR TITLE
feat: implement delete function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ build-GetBookFunction:
 	mv get-book $(ARTIFACTS_DIR)
 	@echo "Built GetBookFunction successfully"
 
+build-DeleteBookFunction:
+	@echo "Building DeleteBookFunction"
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o delete-book github.com/rotiroti/alessandrina/functions/delete-book/
+	mv delete-book $(ARTIFACTS_DIR)
+	@echo "Built DeleteBookFunction successfully"
+
 format:
 	@echo "Format code"
 	go fmt ./...

--- a/domain/book.go
+++ b/domain/book.go
@@ -25,6 +25,7 @@ type UUIDGenerator func() uuid.UUID
 type Storer interface {
 	Save(ctx context.Context, book Book) error
 	FindOne(ctx context.Context, bookID uuid.UUID) (Book, error)
+	Delete(ctx context.Context, bookID uuid.UUID) error
 }
 
 // Service is the domain service for Book.
@@ -72,4 +73,13 @@ func (s *Service) FindOne(ctx context.Context, bookID uuid.UUID) (Book, error) {
 	}
 
 	return book, nil
+}
+
+// Delete removes a book from a storage by using bookID as primary key.
+func (s *Service) Delete(ctx context.Context, bookID uuid.UUID) error {
+	if err := s.storer.Delete(ctx, bookID); err != nil {
+		return fmt.Errorf("delete: bookID[%s]: %w", bookID, err)
+	}
+
+	return nil
 }

--- a/domain/book_test.go
+++ b/domain/book_test.go
@@ -172,3 +172,59 @@ func TestFindOneFail(t *testing.T) {
 	// Assert that the mockStorer's expectations were met
 	mockStorer.AssertExpectations(t)
 }
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock instance of the Storer interface
+	mockStorer := domain.NewMockStorer(t)
+
+	// Generate a fixed UUID for the test
+	expectedID := uuid.MustParse("ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812")
+
+	// Create an instance of the Service struct with the mockStorer
+	service := domain.NewService(mockStorer)
+
+	// Set up the expected inputs and outputs
+	ctx := context.TODO()
+
+	// Set up the expectations for the mockStorer's Delete method
+	mockStorer.EXPECT().Delete(ctx, expectedID).Return(nil).Once()
+
+	// Call the Delete method of the service
+	err := service.Delete(ctx, expectedID)
+
+	// Assert the expected output
+	assert.NoError(t, err)
+
+	// Assert that the mockStorer's expectations were met
+	mockStorer.AssertExpectations(t)
+}
+
+func TestDeleteFail(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock instance of the Storer interface
+	mockStorer := domain.NewMockStorer(t)
+
+	// Generate a fixed UUID for the test
+	bookID := uuid.MustParse("ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812")
+
+	// Create an instance of the Service struct with the mockStorer
+	service := domain.NewService(mockStorer)
+
+	// Set up the expected inputs and outputs
+	ctx := context.TODO()
+
+	// Set up the expectations for the mockStorer's Delete method
+	mockStorer.EXPECT().Delete(ctx, bookID).Return(assert.AnError).Once()
+
+	// Call the Delete method of the service
+	err := service.Delete(ctx, bookID)
+
+	// Assert the expected output
+	assert.Error(t, err)
+
+	// Assert that the mockStorer's expectations were met
+	mockStorer.AssertExpectations(t)
+}

--- a/domain/mock_storer_test.go
+++ b/domain/mock_storer_test.go
@@ -22,6 +22,49 @@ func (_m *MockStorer) EXPECT() *MockStorer_Expecter {
 	return &MockStorer_Expecter{mock: &_m.Mock}
 }
 
+// Delete provides a mock function with given fields: ctx, bookID
+func (_m *MockStorer) Delete(ctx context.Context, bookID uuid.UUID) error {
+	ret := _m.Called(ctx, bookID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
+		r0 = rf(ctx, bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorer_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
+type MockStorer_Delete_Call struct {
+	*mock.Call
+}
+
+// Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bookID uuid.UUID
+func (_e *MockStorer_Expecter) Delete(ctx interface{}, bookID interface{}) *MockStorer_Delete_Call {
+	return &MockStorer_Delete_Call{Call: _e.mock.On("Delete", ctx, bookID)}
+}
+
+func (_c *MockStorer_Delete_Call) Run(run func(ctx context.Context, bookID uuid.UUID)) *MockStorer_Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uuid.UUID))
+	})
+	return _c
+}
+
+func (_c *MockStorer_Delete_Call) Return(_a0 error) *MockStorer_Delete_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorer_Delete_Call) RunAndReturn(run func(context.Context, uuid.UUID) error) *MockStorer_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindOne provides a mock function with given fields: ctx, bookID
 func (_m *MockStorer) FindOne(ctx context.Context, bookID uuid.UUID) (Book, error) {
 	ret := _m.Called(ctx, bookID)

--- a/events/delete-book.json
+++ b/events/delete-book.json
@@ -1,0 +1,110 @@
+{
+    "resource": "/books/{id}",
+    "path": "/ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812",
+    "httpMethod": "DELETE",
+    "pathParameters": {
+      "id": "ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812"
+    },
+    "headers": {
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+      "Accept-Encoding": "gzip, deflate, sdch",
+      "Accept-Language": "en-US,en;q=0.8",
+      "Cache-Control": "max-age=0",
+      "CloudFront-Forwarded-Proto": "https",
+      "CloudFront-Is-Desktop-Viewer": "true",
+      "CloudFront-Is-Mobile-Viewer": "false",
+      "CloudFront-Is-SmartTV-Viewer": "false",
+      "CloudFront-Is-Tablet-Viewer": "false",
+      "CloudFront-Viewer-Country": "US",
+      "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+      "Upgrade-Insecure-Requests": "1",
+      "User-Agent": "Custom User Agent String",
+      "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+      "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+      "X-Forwarded-Port": "443",
+      "X-Forwarded-Proto": "https"
+    },
+    "multiValueHeaders": {
+      "Accept": [
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      ],
+      "Accept-Encoding": [
+        "gzip, deflate, sdch"
+      ],
+      "Accept-Language": [
+        "en-US,en;q=0.8"
+      ],
+      "Cache-Control": [
+        "max-age=0"
+      ],
+      "CloudFront-Forwarded-Proto": [
+        "https"
+      ],
+      "CloudFront-Is-Desktop-Viewer": [
+        "true"
+      ],
+      "CloudFront-Is-Mobile-Viewer": [
+        "false"
+      ],
+      "CloudFront-Is-SmartTV-Viewer": [
+        "false"
+      ],
+      "CloudFront-Is-Tablet-Viewer": [
+        "false"
+      ],
+      "CloudFront-Viewer-Country": [
+        "US"
+      ],
+      "Host": [
+        "0123456789.execute-api.us-east-1.amazonaws.com"
+      ],
+      "Upgrade-Insecure-Requests": [
+        "1"
+      ],
+      "User-Agent": [
+        "Custom User Agent String"
+      ],
+      "Via": [
+        "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)"
+      ],
+      "X-Amz-Cf-Id": [
+        "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA=="
+      ],
+      "X-Forwarded-For": [
+        "127.0.0.1, 127.0.0.2"
+      ],
+      "X-Forwarded-Port": [
+        "443"
+      ],
+      "X-Forwarded-Proto": [
+        "https"
+      ]
+    },
+    "requestContext": {
+      "accountId": "123456789012",
+      "resourceId": "123456",
+      "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+      "requestTime": "09/Apr/2015:12:34:56 +0000",
+      "requestTimeEpoch": 1428582896000,
+      "identity": {
+        "cognitoIdentityPoolId": null,
+        "accountId": null,
+        "cognitoIdentityId": null,
+        "caller": null,
+        "accessKey": null,
+        "sourceIp": "127.0.0.1",
+        "cognitoAuthenticationType": null,
+        "cognitoAuthenticationProvider": null,
+        "userArn": null,
+        "userAgent": "Custom User Agent String",
+        "user": null
+      },
+      "path": "/ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812",
+      "resourcePath": "/books/{id}",
+      "httpMethod": "DELETE",
+      "apiId": "1234567890",
+      "protocol": "HTTP/1.1"
+    }
+  }
+  

--- a/functions/delete-book/main.go
+++ b/functions/delete-book/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/rotiroti/alessandrina/domain"
+	"github.com/rotiroti/alessandrina/sys/database/ddb"
+	"github.com/rotiroti/alessandrina/web"
+)
+
+var (
+	// ErrMissingTableName is returned when the TABLE_NAME environment variable is not set.
+	ErrMissingTableName = errors.New("missing TABLE_NAME environment variable")
+)
+
+func main() {
+	ctx := context.Background()
+	if err := run(ctx); err != nil {
+		log.Fatalf("startup: %v\n", err)
+	}
+}
+
+func run(ctx context.Context) error {
+	// NOTE: Due to the isolated nature of the `in-memory` database across functions,
+	//		 seeding it with data for initialization is essential. However, this seeding process
+	//		 could potentially increase the "cold start" times for the function.
+	//		 Considering that the database is primarily intended for local development purposes,
+	//		 we have decided not to provide the user with the ability to select the storage type
+	//		 using the STORAGE_MEMORY environment variable.
+	tableName, ok := os.LookupEnv("TABLE_NAME")
+	if !ok || tableName == "" {
+		return fmt.Errorf("run: %w", ErrMissingTableName)
+	}
+
+	// Define a custom endpoint resolver to use a local DynamoDB instance.
+	// This is useful for local development, for example with the SAM CLI and LocalStack.
+	customResolver := aws.EndpointResolverWithOptionsFunc(
+		func(_, region string, options ...interface{}) (aws.Endpoint, error) {
+			endpoint := os.Getenv("AWS_ENDPOINT_DEBUG")
+			if endpoint == "" {
+				return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+			}
+
+			return aws.Endpoint{
+				PartitionID:       "aws",
+				URL:               endpoint,
+				SigningRegion:     region,
+				HostnameImmutable: true,
+			}, nil
+		})
+
+	// Enable debug logging to see the HTTP requests and responses bodies.
+	var logMode aws.ClientLogMode
+
+	if os.Getenv("AWS_CLIENT_DEBUG") == "true" {
+		logMode |= aws.LogRequestWithBody | aws.LogResponseWithBody
+	}
+
+	options := []func(*config.LoadOptions) error{
+		config.WithEndpointResolverWithOptions(customResolver),
+		config.WithClientLogMode(logMode),
+	}
+
+	// TODO: This is a temporary solution to check if we can connect to DynamoDB.
+	//		 We should declare a Config struct in the ddb package, and use it
+	//		 instead of instantiating the DynamoDB client here.
+	conf, err := config.LoadDefaultConfig(ctx, options...)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate a new DynamoDB store
+	store := ddb.NewStore(tableName, dynamodb.NewFromConfig(conf))
+
+	// Instantiate a new domain service
+	service := domain.NewService(store)
+
+	// Instantiate a new handler
+	handler := web.NewAPIGatewayV2Handler(service)
+
+	// Start the lambda handler listening for DeleteBook events.
+	lambda.Start(handler.DeleteBook)
+
+	return nil
+}

--- a/locals.json
+++ b/locals.json
@@ -8,5 +8,10 @@
         "TABLE_NAME": "BooksTable-local",
         "AWS_ENDPOINT_DEBUG": "http://localstack_main:4566",
         "AWS_CLIENT_DEBUG": true
+    },
+    "DeleteBookFunction": {
+        "TABLE_NAME": "BooksTable-local",
+        "AWS_ENDPOINT_DEBUG": "http://localstack_main:4566",
+        "AWS_CLIENT_DEBUG": true
     }
 }

--- a/sys/database/ddb/mock_dynamodb_api_test.go
+++ b/sys/database/ddb/mock_dynamodb_api_test.go
@@ -22,6 +22,76 @@ func (_m *MockDynamodbAPI) EXPECT() *MockDynamodbAPI_Expecter {
 	return &MockDynamodbAPI_Expecter{mock: &_m.Mock}
 }
 
+// DeleteItem provides a mock function with given fields: ctx, params, optFns
+func (_m *MockDynamodbAPI) DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *dynamodb.DeleteItemOutput
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)); ok {
+		return rf(ctx, params, optFns...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) *dynamodb.DeleteItemOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dynamodb.DeleteItemOutput)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDynamodbAPI_DeleteItem_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteItem'
+type MockDynamodbAPI_DeleteItem_Call struct {
+	*mock.Call
+}
+
+// DeleteItem is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *dynamodb.DeleteItemInput
+//   - optFns ...func(*dynamodb.Options)
+func (_e *MockDynamodbAPI_Expecter) DeleteItem(ctx interface{}, params interface{}, optFns ...interface{}) *MockDynamodbAPI_DeleteItem_Call {
+	return &MockDynamodbAPI_DeleteItem_Call{Call: _e.mock.On("DeleteItem",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *MockDynamodbAPI_DeleteItem_Call) Run(run func(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options))) *MockDynamodbAPI_DeleteItem_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*dynamodb.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*dynamodb.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*dynamodb.DeleteItemInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockDynamodbAPI_DeleteItem_Call) Return(_a0 *dynamodb.DeleteItemOutput, _a1 error) *MockDynamodbAPI_DeleteItem_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDynamodbAPI_DeleteItem_Call) RunAndReturn(run func(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)) *MockDynamodbAPI_DeleteItem_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetItem provides a mock function with given fields: ctx, params, optFns
 func (_m *MockDynamodbAPI) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	_va := make([]interface{}, len(optFns))

--- a/sys/database/memory/memory.go
+++ b/sys/database/memory/memory.go
@@ -50,3 +50,17 @@ func (s *Store) FindOne(_ context.Context, bookID uuid.UUID) (domain.Book, error
 
 	return book, nil
 }
+
+// Delete removes a book from the in-memory database.
+func (s *Store) Delete(_ context.Context, bookID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.container[bookID.String()]; !exists {
+		return domain.ErrNotFound
+	}
+
+	delete(s.container, bookID.String())
+
+	return nil
+}

--- a/sys/database/memory/memory_test.go
+++ b/sys/database/memory/memory_test.go
@@ -53,4 +53,20 @@ func TestMemoryStore(t *testing.T) {
 		_, err := store.FindOne(context.Background(), book.ID)
 		require.ErrorIs(t, err, domain.ErrNotFound)
 	})
+
+	t.Run("should delete an existing book", func(t *testing.T) {
+		t.Parallel()
+		store := memory.NewStore()
+		err := store.Save(context.Background(), book)
+		require.NoError(t, err)
+		err2 := store.Delete(context.Background(), book.ID)
+		require.NoError(t, err2)
+	})
+
+	t.Run("should throw error for deleting a non existing book", func(t *testing.T) {
+		t.Parallel()
+		store := memory.NewStore()
+		err := store.Delete(context.Background(), book.ID)
+		require.ErrorIs(t, err, domain.ErrNotFound)
+	})
 }

--- a/template.yaml
+++ b/template.yaml
@@ -79,6 +79,25 @@ Resources:
             Path: /books/{id}
             Method: GET
 
+  DeleteBookFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: makefile
+    Properties:
+      CodeUri: .
+      Handler: delete-book
+      Description: Delete a book
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref BooksTable
+      Events:
+        ApiEvent:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref BooksAPI
+            Path: /books/{id}
+            Method: DELETE
+
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for the Books API"
@@ -91,3 +110,7 @@ Outputs:
   GetBookFunction:
     Description: "GetBook Lambda Function ARN"
     Value: !GetAtt GetBookFunction.Arn
+
+  DeleteBookFunction:
+    Description: "DeleteBook Lambda Function ARN"
+    Value: !GetAtt DeleteBookFunction.Arn

--- a/tests/integration/dynamodb_test.go
+++ b/tests/integration/dynamodb_test.go
@@ -66,7 +66,10 @@ func setupLocalstack(t *testing.T) (tableName string, client *dynamodb.Client) {
 }
 
 func TestDynamodbFlow(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
+
+	os.Setenv("LOCALSTACK", "true")
+	os.Setenv("TABLE_NAME", "BooksTable-local")
 
 	// Skip the DynamoDB test if the LOCALSTACK environment variable is not set
 	skipLocalstack(t)
@@ -76,7 +79,7 @@ func TestDynamodbFlow(t *testing.T) {
 	tableName, client := setupLocalstack(t)
 
 	t.Run("Save", func(t *testing.T) {
-		t.Parallel()
+		// t.Parallel()
 
 		// Create a new book
 		bookID := uuid.MustParse("ad8b59c2-5fe6-4267-b0cf-6d2f9eb1c812")
@@ -103,7 +106,7 @@ func TestDynamodbFlow(t *testing.T) {
 	})
 
 	t.Run("SaveTableNotExist", func(t *testing.T) {
-		t.Parallel()
+		// t.Parallel()
 
 		// Create a new store using the Localstack DynamoDB instance
 		store := ddb.NewStore("not-exist", client)
@@ -116,7 +119,7 @@ func TestDynamodbFlow(t *testing.T) {
 	})
 
 	t.Run("FindOne", func(t *testing.T) {
-		t.Parallel()
+		// t.Parallel()
 
 		// Create a new book
 		bookID := uuid.MustParse("ad8b59c2-5fe6-4267-b0cf-6d2f9eb1cabd")
@@ -148,8 +151,8 @@ func TestDynamodbFlow(t *testing.T) {
 		require.Equal(t, expectedBook, book)
 	})
 
-	t.Run("FindOneBookNotFoun", func(t *testing.T) {
-		t.Parallel()
+	t.Run("FindOneBookNotFound", func(t *testing.T) {
+		// t.Parallel()
 
 		// Create a new book
 		bookID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
@@ -159,6 +162,52 @@ func TestDynamodbFlow(t *testing.T) {
 
 		// Call the FindOne method of the store
 		_, err := store.FindOne(ctx, bookID)
+
+		// Assert the expected output
+		require.Error(t, err)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		// t.Parallel()
+
+		// Create a new book
+		bookID := uuid.MustParse("ad8b59c2-5fe6-4267-b0cf-6d2f9eb1cabd")
+		expectedBook := domain.Book{
+			ID:        bookID,
+			Title:     "The Lord of the Rings",
+			Authors:   "J.R.R. Tolkien",
+			Pages:     1178,
+			Publisher: "George Allen & Unwin",
+			ISBN:      "978-0-261-10235-4",
+		}
+
+		// Create a new store using the Localstack DynamoDB instance
+		store := ddb.NewStore(tableName, client)
+
+		// Call the Save method of the store
+		err := store.Save(ctx, expectedBook)
+
+		// Assert the expected output
+		require.NoError(t, err)
+
+		// Call the Delete method of the store
+		err = store.Delete(ctx, bookID)
+
+		// Assert the expected output
+		require.NoError(t, err)
+	})
+
+	t.Run("DeleteBookNotFound", func(t *testing.T) {
+		// t.Parallel()
+
+		// Create a new book
+		bookID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
+
+		// Create a new store using the Localstack DynamoDB instance
+		store := ddb.NewStore(tableName, client)
+
+		// Call the Delete method of the store
+		err := store.Delete(ctx, bookID)
 
 		// Assert the expected output
 		require.Error(t, err)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -127,4 +127,21 @@ func TestIntegrationFlow(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code %d but got %d", http.StatusOK, resp.StatusCode)
 	}
+
+	// --- DeleteBook scenario ---
+	req, err = http.NewRequest(http.MethodDelete, bookURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code to be 204
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("Expected status code %d but got %d", http.StatusOK, resp.StatusCode)
+	}
 }

--- a/tests/performance/flow.yml
+++ b/tests/performance/flow.yml
@@ -13,61 +13,61 @@ config:
     load-test:
       target: "{{ $processEnvironment.API_URL }}"
       phases:
-      - name: "Ramp up to peak load in 5 minutes"
-        duration: 300
-        rampTo: 3
-      - name: "Sustain peak load for 10 minutes"
-        duration: 600
-        arrivalRate: 3
-      - name: "Ramp down to zero in 5 minutes"
-        duration: 300
-        arrivalRate: 3
-        rampTo: 0
+        - name: "Ramp up to peak load in 5 minutes"
+          duration: 300
+          rampTo: 3
+        - name: "Sustain peak load for 10 minutes"
+          duration: 600
+          arrivalRate: 3
+        - name: "Ramp down to zero in 5 minutes"
+          duration: 300
+          arrivalRate: 3
+          rampTo: 0
     stress-test:
       target: "{{ $processEnvironment.API_URL }}"
       phases:
-      - name: "Ramp up to peak load in 2 minutes"
-        duration: 120
-        rampTo: 15
-      - name: "Sustain peak load for 5 minutes"
-        duration: 300
-        arrivalRate: 15
-      - name: "Ramp up to peak load in 2 minutes"
-        duration: 120
-        rampTo: 50
-      - name: "Sustain peak load for 5 minutes"
-        duration: 300
-        arrivalRate: 50
-      - name: "Ramp down to zero in 10 minutes"
-        duration: 600
-        arrivalRate: 50
-        rampTo: 0
+        - name: "Ramp up to peak load in 2 minutes"
+          duration: 120
+          rampTo: 15
+        - name: "Sustain peak load for 5 minutes"
+          duration: 300
+          arrivalRate: 15
+        - name: "Ramp up to peak load in 2 minutes"
+          duration: 120
+          rampTo: 50
+        - name: "Sustain peak load for 5 minutes"
+          duration: 300
+          arrivalRate: 50
+        - name: "Ramp down to zero in 10 minutes"
+          duration: 600
+          arrivalRate: 50
+          rampTo: 0
     spike-test:
       target: "{{ $processEnvironment.API_URL }}"
       phases:
-      - name: "Ramp up to peak load in 10 seconds"
-        duration: 10
-        arrivalRate: 15
-      - name: "Sustain peak load for 5 minutes"
-        duration: 60
-        arrivalRate: 15
-      - name: "Spike to 50 vusers for 10 seconds"
-        duration: 10
-        rampTo: 50
-      - name: "Sustain peak load for 3 minutes"
-        duration: 60
-        arrivalRate: 50
-      - name: "Ramp down to zero in 10 minutes"
-        duration: 10
-        arrivalRate: 50
-        rampTo: 15
-      - name: "Sustain peak load for 3 minutes"
-        duration: 180
-        arrivalRate: 15
-      - name: "Ramp down to zero in 10 minutes"
-        duration: 10
-        arrivalRate: 15
-        rampTo: 0
+        - name: "Ramp up to peak load in 10 seconds"
+          duration: 10
+          arrivalRate: 15
+        - name: "Sustain peak load for 5 minutes"
+          duration: 60
+          arrivalRate: 15
+        - name: "Spike to 50 vusers for 10 seconds"
+          duration: 10
+          rampTo: 50
+        - name: "Sustain peak load for 3 minutes"
+          duration: 60
+          arrivalRate: 50
+        - name: "Ramp down to zero in 10 minutes"
+          duration: 10
+          arrivalRate: 50
+          rampTo: 15
+        - name: "Sustain peak load for 3 minutes"
+          duration: 180
+          arrivalRate: 15
+        - name: "Ramp down to zero in 10 minutes"
+          duration: 10
+          arrivalRate: 15
+          rampTo: 0
   processor: "./generator.js"
   default:
     headers:
@@ -80,22 +80,26 @@ config:
     maxErrors: 0
 scenarios:
   - flow:
-    - function: "generateRandomData"
-    - post:
-        url: "/books"
-        json:
-          title: "{{ title }}"
-          authors: "{{ authors }}"
-          isbn: "{{ isbn }}"
-          pages: "{{ pages }}"
-          publisher: "{{ publisher }}"
-        expect:
-          statusCode: 201
-          hasProperty: "id"
-        capture:
-          json: "$.id"
-          as: "id"
-    - get:
-        url: "/books/{{ id }}"
-        expect:
-          statusCode: 200
+      - function: "generateRandomData"
+      - post:
+          url: "/books"
+          json:
+            title: "{{ title }}"
+            authors: "{{ authors }}"
+            isbn: "{{ isbn }}"
+            pages: "{{ pages }}"
+            publisher: "{{ publisher }}"
+          expect:
+            statusCode: 201
+            hasProperty: "id"
+          capture:
+            json: "$.id"
+            as: "id"
+      - get:
+          url: "/books/{{ id }}"
+          expect:
+            statusCode: 200
+      - delete:
+          url: "/books/{{ id }}"
+          expect:
+            statusCode: 204

--- a/web/apigateway.go
+++ b/web/apigateway.go
@@ -54,6 +54,20 @@ func (h *APIGatewayV2Handler) GetBook(ctx context.Context, req events.APIGateway
 	return jsonResponse(http.StatusOK, ToAppBook(book)), nil
 }
 
+// DeleteBook handles requests for deleting a book by a given ID (UUID).
+func (h *APIGatewayV2Handler) DeleteBook(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	id, err := uuid.Parse(req.PathParameters["id"])
+	if err != nil {
+		return errorResponse(http.StatusBadRequest, err.Error()), nil
+	}
+
+	if err := h.service.Delete(ctx, id); err != nil {
+		return errorResponse(http.StatusInternalServerError, err.Error()), nil
+	}
+
+	return jsonResponse(http.StatusNoContent, nil), nil
+}
+
 func jsonResponse(code int, obj any) events.APIGatewayV2HTTPResponse {
 	body, err := json.Marshal(obj)
 	if err != nil {


### PR DESCRIPTION
This PR introduces the implementation of an endpoint to delete a book using an existing UUID.
Here's an overview of the included changes:

- Define a new method for the Storer interface to delete a book from storage using a UUID as the primary key
- Implementation of the `Delete` method for both storage (in-memory and DynamoDB)
- Update mocks, unit and integration tests to cover the new function
