### PR TITLE
fix: set SLO test 'maxErrorRate' assertion to 1%

### DIFF
--- a/tests/performance/slo.yml
+++ b/tests/performance/slo.yml
@@ -34,7 +34,7 @@ config:
       Content-Type: "application/json"
   ensure:
     p95: 400
-    maxErrorsRate: 1
+    maxErrorRate: 1
 scenarios:
   - name: "Create, List, Read, Delete"
     flow:


### PR DESCRIPTION
This PR fixes the key 'maxErrorRate' typo in the SLO configuration test. With this fix, if the automatic/manual load testing job fails, the workflow will only stop if we receive more than 1% of errors.