### PR TITLE
feat: switch to On-Demand capacity mode

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -226,45 +226,45 @@ jobs:
         run: |
           echo "API_URL=${{ needs.deploy-dev.outputs.API_URL }}" >> $GITHUB_OUTPUT
 
-  load-tests:
-    if: github.ref == 'refs/heads/main'
-    needs: [integration-tests]
-    runs-on: ubuntu-latest
-    container: artilleryio/artillery:latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  # load-tests:
+  #   if: github.ref == 'refs/heads/main'
+  #   needs: [integration-tests]
+  #   runs-on: ubuntu-latest
+  #   container: artilleryio/artillery:latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Install additional dependencies
-        run: npm install -g artillery-plugin-expect artillery-plugin-ensure
+  #     - name: Install additional dependencies
+  #       run: npm install -g artillery-plugin-expect artillery-plugin-ensure
 
-      - name: Make reports directory
-        run: mkdir reports
+  #     - name: Make reports directory
+  #       run: mkdir reports
 
-      - name: Execute smoke test
-        run: |
-          API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/smoke.json tests/performance/smoke.yml
-          /home/node/artillery/bin/run report --output reports/smoke.html reports/smoke.json
+  #     - name: Execute smoke test
+  #       run: |
+  #         API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/smoke.json tests/performance/smoke.yml
+  #         /home/node/artillery/bin/run report --output reports/smoke.html reports/smoke.json
 
-      - name: Execute load test (CRD book)
-        run: |
-          API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/load-crd.json tests/performance/load-crd.yml
-          /home/node/artillery/bin/run report --output reports/load-crd.html reports/load-crd.json
+  #     - name: Execute load test (CRD book)
+  #       run: |
+  #         API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/load-crd.json tests/performance/load-crd.yml
+  #         /home/node/artillery/bin/run report --output reports/load-crd.html reports/load-crd.json
 
-      - name: Execute SLO test (p95=400, error rate=0.01)
-        run: |
-          API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/slo30sec10vus.json --environment=slo30sec10vus tests/performance/slo.yml
-          /home/node/artillery/bin/run report --output reports/slo30sec10vus.html reports/slo30sec10vus.json
+  #     - name: Execute SLO test (p95=400, error rate=0.01)
+  #       run: |
+  #         API_URL=${{ needs.integration-tests.outputs.API_URL }} /home/node/artillery/bin/run run --output reports/slo30sec10vus.json --environment=slo30sec10vus tests/performance/slo.yml
+  #         /home/node/artillery/bin/run report --output reports/slo30sec10vus.html reports/slo30sec10vus.json
 
-      - name: Archive test report
-        uses: actions/upload-artifact@v3
-        with:
-          name: artillery-test-report
-          path: reports/*
+  #     - name: Archive test report
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: artillery-test-report
+  #         path: reports/*
 
   deploy-prod:
     if: github.ref == 'refs/heads/main'
-    needs: [load-tests]
+    needs: [integration-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/scripts/create-table.sh
+++ b/scripts/create-table.sh
@@ -26,4 +26,4 @@ aws dynamodb create-table \
     --table-name "$table_name" \
     --attribute-definitions AttributeName=id,AttributeType=S \
     --key-schema AttributeName=id,KeyType=HASH \
-    --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1
+    --billing-mode PAY_PER_REQUEST

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Globals:
         DEBUG_MODE: false
     AutoPublishAlias: live
     DeploymentPreference:
-      Type: !If [IsProduction, "Canary10Percent5Minutes", "AllAtOnce"]
+      Type: !If [IsProduction, "Canary10Percent10Minutes", "AllAtOnce"]
 
 Conditions:
   IsProduction: !Equals [!Ref "AWS::StackName", "alessandrina-prod"]
@@ -32,14 +32,15 @@ Resources:
       RetentionInDays: 7
 
   BooksTable:
-    Type: AWS::Serverless::SimpleTable
+    Type: AWS::DynamoDB::Table
     Properties:
-      PrimaryKey:
-        Name: id
-        Type: String
-      ProvisionedThroughput:
-        ReadCapacityUnits: 10
-        WriteCapacityUnits: 10
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
 
   GetBooksFunction:
     Type: AWS::Serverless::Function

--- a/tests/performance/generator.js
+++ b/tests/performance/generator.js
@@ -86,7 +86,7 @@ const generateRandomData = (context, events, done) => {
     const authors = AUTHORS[Math.floor(Math.random() * AUTHORS.length)];
     const isbn = ISBN[Math.floor(Math.random() * ISBN.length)];
     const publisher = PUBLISHER[Math.floor(Math.random() * PUBLISHER.length)];
-    const pages = Math.floor(Math.random() * 1000);
+    const pages = Math.floor(Math.random() * 1000) + 1;
 
     context.vars.title = title;
     context.vars.authors = authors;


### PR DESCRIPTION
This PR sets DynamoDB on-demand capacity instead of 10 read/write provisioned capacity.
Here's an overview of the included changes:

- Set DynamoDB on-demand capacity instead of 10 read/write provisioned capacity.
- Disable load testing before deploying to production.
- Set canary release to 10 per cent in 10 minutes.
- Update load testing generator function to generate a random book with at least one page.