### PR TITLE
refactor: handle book not found for GetBook and DeleteBook methods

### DIFF
--- a/domain/book.go
+++ b/domain/book.go
@@ -58,7 +58,7 @@ func (c *BookCore) Save(ctx context.Context, nb NewBook) (Book, error) {
 	}
 
 	if err := c.storer.Save(ctx, book); err != nil {
-		return Book{}, fmt.Errorf("save: %w", err)
+		return Book{}, fmt.Errorf("domain.save failed: %w", err)
 	}
 
 	return book, nil
@@ -68,7 +68,7 @@ func (c *BookCore) Save(ctx context.Context, nb NewBook) (Book, error) {
 func (c *BookCore) FindAll(ctx context.Context) ([]Book, error) {
 	books, err := c.storer.FindAll(ctx)
 	if err != nil {
-		return []Book{}, fmt.Errorf("findall: %w", err)
+		return []Book{}, fmt.Errorf("domain.findall failed: %w", err)
 	}
 
 	return books, nil
@@ -78,7 +78,7 @@ func (c *BookCore) FindAll(ctx context.Context) ([]Book, error) {
 func (c *BookCore) FindOne(ctx context.Context, bookID uuid.UUID) (Book, error) {
 	book, err := c.storer.FindOne(ctx, bookID)
 	if err != nil {
-		return Book{}, fmt.Errorf("findone: bookID[%s]: %w", bookID, err)
+		return Book{}, fmt.Errorf("domain.findone failed: %w", err)
 	}
 
 	return book, nil
@@ -87,7 +87,7 @@ func (c *BookCore) FindOne(ctx context.Context, bookID uuid.UUID) (Book, error) 
 // Delete removes a book from a storage by using bookID as primary key.
 func (c *BookCore) Delete(ctx context.Context, bookID uuid.UUID) error {
 	if err := c.storer.Delete(ctx, bookID); err != nil {
-		return fmt.Errorf("delete: bookID[%s]: %w", bookID, err)
+		return fmt.Errorf("domain.delete failed: %w", err)
 	}
 
 	return nil

--- a/sys/database/memory/memory.go
+++ b/sys/database/memory/memory.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
@@ -30,7 +31,7 @@ func (s *Store) Save(_ context.Context, book domain.Book) error {
 	defer s.mu.Unlock()
 
 	if _, exists := s.container[book.ID.String()]; exists {
-		return domain.ErrAlreadyExists
+		return fmt.Errorf("memory.save: %w", domain.ErrAlreadyExists)
 	}
 
 	s.container[book.ID.String()] = book
@@ -58,7 +59,7 @@ func (s *Store) FindOne(_ context.Context, bookID uuid.UUID) (domain.Book, error
 
 	book, exists := s.container[bookID.String()]
 	if !exists {
-		return domain.Book{}, domain.ErrNotFound
+		return domain.Book{}, fmt.Errorf("memory.findone: %w", domain.ErrNotFound)
 	}
 
 	return book, nil
@@ -70,7 +71,7 @@ func (s *Store) Delete(_ context.Context, bookID uuid.UUID) error {
 	defer s.mu.Unlock()
 
 	if _, exists := s.container[bookID.String()]; !exists {
-		return domain.ErrNotFound
+		return fmt.Errorf("memory.findone: %w", domain.ErrNotFound)
 	}
 
 	delete(s.container, bookID.String())

--- a/sys/validation/validation.go
+++ b/sys/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -78,7 +79,7 @@ func (c *Config) Check(val any) error {
 		// Use a type assertion to get the real error value.
 		verrors, ok := err.(validator.ValidationErrors)
 		if !ok {
-			return err
+			return fmt.Errorf("validation.check: %w", err)
 		}
 
 		var fields FieldErrors

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -188,15 +188,6 @@ func TestErrorResponses(t *testing.T) {
 			want: http.StatusBadRequest,
 		},
 		{
-			name: "GetBookIdNotFound",
-			args: args{
-				method: http.MethodGet,
-				url:    fmt.Sprintf("%s/%s", baseURL, uuid.New().String()),
-				body:   nil,
-			},
-			want: http.StatusInternalServerError,
-		},
-		{
 			name: "CreateBookInvalidPayload",
 			args: args{
 				method: http.MethodPost,
@@ -222,15 +213,6 @@ func TestErrorResponses(t *testing.T) {
 				body:   nil,
 			},
 			want: http.StatusBadRequest,
-		},
-		{
-			name: "DeleteBookIdNotFound",
-			args: args{
-				method: http.MethodDelete,
-				url:    fmt.Sprintf("%s/%s", baseURL, uuid.New().String()),
-				body:   nil,
-			},
-			want: http.StatusInternalServerError,
 		},
 	}
 

--- a/tests/performance/slo.yml
+++ b/tests/performance/slo.yml
@@ -69,4 +69,3 @@ scenarios:
           expect:
             statusCode:
               - 204
-              - 500

--- a/web/apigateway.go
+++ b/web/apigateway.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -65,6 +66,10 @@ func (h *APIGatewayV2Handler) GetBook(ctx context.Context, req events.APIGateway
 
 	ret, err := h.book.FindOne(ctx, id)
 	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return errorResponse(http.StatusNotFound, err.Error()), nil
+		}
+
 		return errorResponse(http.StatusInternalServerError, err.Error()), nil
 	}
 
@@ -79,6 +84,10 @@ func (h *APIGatewayV2Handler) DeleteBook(ctx context.Context, req events.APIGate
 	}
 
 	if err := h.book.Delete(ctx, id); err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return jsonResponse(http.StatusNoContent, nil), nil
+		}
+
 		return errorResponse(http.StatusInternalServerError, err.Error()), nil
 	}
 

--- a/web/apigateway_test.go
+++ b/web/apigateway_test.go
@@ -140,7 +140,7 @@ func TestHandler(t *testing.T) {
 		require.JSONEq(t, expectedJSONBook, ret.Body)
 	})
 
-	t.Run("GetBookInternalServerError", func(t *testing.T) {
+	t.Run("GetBookNotFound", func(t *testing.T) {
 		store := memory.NewStore()
 		bookCore := domain.NewBookCore(store)
 		handler := web.NewAPIGatewayV2Handler(bookCore)
@@ -148,6 +148,21 @@ func TestHandler(t *testing.T) {
 		ret, err := handler.GetBook(ctx, events.APIGatewayV2HTTPRequest{
 			PathParameters: map[string]string{
 				"id": parameterID,
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, ret.StatusCode)
+	})
+
+	t.Run("GetBookInternalServerError", func(t *testing.T) {
+		store := new(MockStorer)
+		store.On("FindOne", ctx, expectedID).Return(domain.Book{}, assert.AnError).Once()
+		bookCore := domain.NewBookCore(store)
+		handler := web.NewAPIGatewayV2Handler(bookCore)
+		ret, err := handler.GetBook(ctx, events.APIGatewayV2HTTPRequest{
+			PathParameters: map[string]string{
+				"id": expectedID.String(),
 			},
 		})
 
@@ -174,7 +189,7 @@ func TestHandler(t *testing.T) {
 		require.JSONEq(t, expectedJSONBook, ret.Body)
 	})
 
-	t.Run("DeleteBookInternalServerError", func(t *testing.T) {
+	t.Run("DeleteBookNotFound", func(t *testing.T) {
 		store := memory.NewStore()
 		bookCore := domain.NewBookCore(store)
 		handler := web.NewAPIGatewayV2Handler(bookCore)
@@ -182,6 +197,21 @@ func TestHandler(t *testing.T) {
 		ret, err := handler.DeleteBook(ctx, events.APIGatewayV2HTTPRequest{
 			PathParameters: map[string]string{
 				"id": parameterID,
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, ret.StatusCode)
+	})
+
+	t.Run("DeleteBookInternalServerError", func(t *testing.T) {
+		store := new(MockStorer)
+		store.On("Delete", ctx, expectedID).Return(assert.AnError).Once()
+		bookCore := domain.NewBookCore(store)
+		handler := web.NewAPIGatewayV2Handler(bookCore)
+		ret, err := handler.DeleteBook(ctx, events.APIGatewayV2HTTPRequest{
+			PathParameters: map[string]string{
+				"id": expectedID.String(),
 			},
 		})
 


### PR DESCRIPTION
This PR reviews the error messages and the HTTP status codes for the GetBook and DeleteBook `web` methods.
Here's an overview of the included changes:

- `web.GetBook` now returns an HTTP 404 status code when a book is not found.
- `web.DeleteBook` now returns HTTP 204 status code in case a book is not found or was previously deleted.
- Package name included in the error message.